### PR TITLE
Fix bug in {R, Shift}::id() calculation

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -91,8 +91,8 @@ impl R {
     }
 
     #[inline(always)]
-    pub const fn id(&self) -> u32 {
-        self.funct3.as_u32() + self.funct7.as_u32()
+    pub const fn id(&self) -> U10 {
+        unsafe { U10::new_unchecked((self.funct7.as_u16() << 3) | self.funct3.as_u16()) }
     }
 }
 
@@ -136,8 +136,8 @@ impl I {
     }
 
     #[inline(always)]
-    pub const fn id(&self) -> u32 {
-        self.funct3.as_u32()
+    pub const fn id(&self) -> U3 {
+        self.funct3
     }
 }
 
@@ -173,8 +173,8 @@ impl Shift {
     }
 
     #[inline(always)]
-    pub const fn id(&self) -> u32 {
-        self.funct3.as_u32() + self.prefix.as_u32()
+    pub const fn id(&self) -> U10 {
+        unsafe { U10::new_unchecked((self.prefix.as_u16() << 3) | self.funct3.as_u16()) }
     }
 }
 
@@ -229,8 +229,8 @@ impl S {
     }
 
     #[inline(always)]
-    pub const fn id(&self) -> u32 {
-        self.funct3.as_u32()
+    pub const fn id(&self) -> U3 {
+        self.funct3
     }
 }
 
@@ -266,8 +266,8 @@ impl B {
     }
 
     #[inline(always)]
-    pub const fn id(&self) -> u32 {
-        self.funct3.as_u32()
+    pub const fn id(&self) -> U3 {
+        self.funct3
     }
 }
 
@@ -582,18 +582,26 @@ impl_u8!( U7, 7,
           U3  > as_u8  => from_u3,
           U4  > as_u8  => from_u4,
           U5  > as_u8  => from_u5);
-impl_u16!(U12, 12,
+impl_u16!(U10, 10,
           U2  > as_u8  => from_u2,
           U3  > as_u8  => from_u3,
           U4  > as_u8  => from_u4,
           U5  > as_u8  => from_u5,
           U7  > as_u8  => from_u7);
+impl_u16!(U12, 12,
+          U2  > as_u8  => from_u2,
+          U3  > as_u8  => from_u3,
+          U4  > as_u8  => from_u4,
+          U5  > as_u8  => from_u5,
+          U7  > as_u8  => from_u7,
+          U10 > as_u16 => from_u10);
 impl_u16!(U13, 13,
           U2  > as_u8  => from_u2,
           U3  > as_u8  => from_u3,
           U4  > as_u8  => from_u4,
           U5  > as_u8  => from_u5,
           U7  > as_u8  => from_u7,
+          U10 > as_u16 => from_u10,
           U12 > as_u16 => from_u12);
 impl_u32!(U21, 21,
           U2  > as_u8  => from_u2,
@@ -601,6 +609,7 @@ impl_u32!(U21, 21,
           U4  > as_u8  => from_u4,
           U5  > as_u8  => from_u5,
           U7  > as_u8  => from_u7,
+          U10 > as_u16 => from_u10,
           U12 > as_u16 => from_u12,
           U13 > as_u16 => from_u13);
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,8 +1,57 @@
-use crate::decode::{Shift, B, I, J, R, S, U, U12};
+use crate::decode::{Shift, B, I, J, R, S, U, U10, U12, U3};
 use crate::error::Error;
 use crate::registers::{Registers, ZeroOrRegister};
 
 const OPCODE_SIZE: u32 = 4;
+
+macro_rules! def_uconst {
+    ($($v:vis const $name:ident: $t:ty = $n:expr;)*) => {
+        $(
+            #[allow(clippy::unusual_byte_groupings)]
+            $v const $name: $t = if let Some(n) = <$t>::new($n) {
+                n
+            } else {
+                panic!(concat!("Value ", stringify!($n), " out of ", stringify!($t), " range"))
+            };
+        )*
+    };
+}
+
+def_uconst! {
+    const ADD: U10 = 0b0000000_000;
+    const SUB: U10 = 0b0100000_000;
+    const SLL: U10 = 0b0000000_001;
+    const SLT: U10 = 0b0000000_010;
+    const SLTU: U10 = 0b0000000_011;
+    const XOR: U10 = 0b0000000_100;
+    const SRL: U10 = 0b0000000_101;
+    const SRA: U10 = 0b0100000_101;
+    const OR: U10 = 0b0000000_110;
+    const AND: U10 = 0b0000000_111;
+    const ADDI: U3 = 0b000;
+    const SLTI: U3 = 0b010;
+    const SLTIU: U3 = 0b011;
+    const XORI: U3 = 0b100;
+    const ORI: U3 = 0b110;
+    const ANDI: U3 = 0b111;
+    const LB: U3 = 0b000;
+    const LBU: U3 = 0b100;
+    const LH: U3 = 0b001;
+    const LHU: U3 = 0b101;
+    const LW: U3 = 0b010;
+    const SLLI: U10 = 0b0000000_001;
+    const SRLI: U10 = 0b0000000_101;
+    const SRAI: U10 = 0b0100000_101;
+    const SB: U3 = 0b000;
+    const SH: U3 = 0b001;
+    const SW: U3 = 0b010;
+    const BEQ: U3 = 0b000;
+    const BNE: U3 = 0b001;
+    const BLT: U3 = 0b100;
+    const BGE: U3 = 0b101;
+    const BLTU: U3 = 0b110;
+    const BGEU: U3 = 0b111;
+}
 
 #[inline(always)]
 pub(crate) fn execute_math(instruction: R, regs: &mut Registers<u32>) -> Result<(), Error> {
@@ -22,32 +71,21 @@ pub(crate) fn execute_math(instruction: R, regs: &mut Registers<u32>) -> Result<
         }
     }
 
-    #[allow(clippy::unusual_byte_groupings)]
-    let f = match instruction.id().as_u16() {
-        // ADD
-        0b0000000_000 => u32::wrapping_add,
-        // SUB
-        0b0100000_000 => u32::wrapping_sub,
-        // SLL (rs2 truncated)
-        0b0000000_001 => u32::wrapping_shl, // wrapping shl is already masking with (0b11111)
-        // SLT
-        0b0000000_010 => {
+    let f = match instruction.id() {
+        ADD => u32::wrapping_add,
+        SUB => u32::wrapping_sub,
+        SLL => u32::wrapping_shl, // wrapping shl is already masking with (0b11111)
+        SLT => {
             |a, b| unsafe { (core::mem::transmute::<_, i32>(a) < core::mem::transmute(b)) as u32 }
         }
-        // SLTU
-        0b0000000_011 => |a, b| (a < b) as u32,
-        // XOR
-        0b0000000_100 => std::ops::BitXor::bitxor,
-        // SRL (rs2 truncated)
-        0b0000000_101 => u32::wrapping_shr,
-        // SRA (rs2 truncated)
-        0b0100000_101 => |a, b| unsafe {
+        SLTU => |a, b| (a < b) as u32,
+        XOR => std::ops::BitXor::bitxor,
+        SRL => u32::wrapping_shr,
+        SRA => |a, b| unsafe {
             core::mem::transmute(core::mem::transmute::<_, i32>(a).wrapping_shr(b))
         },
-        // OR
-        0b0000000_110 => std::ops::BitOr::bitor,
-        // AND
-        0b0000000_111 => std::ops::BitAnd::bitand,
+        OR => std::ops::BitOr::bitor,
+        AND => std::ops::BitAnd::bitand,
         _ => return Err(Error::InvalidOpCode),
     };
 
@@ -71,23 +109,17 @@ pub(crate) fn execute_mathi(instruction: I, regs: &mut Registers<u32>) -> Result
         }
     }
 
-    let f: fn(u32, U12) -> u32 = match instruction.id().as_u8() {
-        // ADDI
-        0 => |a, b| a.wrapping_add(b.as_u32()),
-        // SLTI
-        2 => |a, b| {
+    let f: fn(u32, U12) -> u32 = match instruction.id() {
+        ADDI => |a, b| a.wrapping_add(b.as_u32()),
+        SLTI => |a, b| {
             let a: i32 = unsafe { core::mem::transmute(a) };
             let b = b.sign_extend() as i32;
             (a < b) as u32
         },
-        // SLTIU
-        3 => |a, b| (a < b.as_u32()) as u32,
-        // XORI
-        4 => |a, b| a ^ b.as_u32(),
-        // ORI
-        5 => |a, b| a | b.as_u32(),
-        // ANDI
-        7 => |a, b| a & b.as_u32(),
+        SLTIU => |a, b| (a < b.as_u32()) as u32,
+        XORI => |a, b| a ^ b.as_u32(),
+        ORI => |a, b| a | b.as_u32(),
+        ANDI => |a, b| a & b.as_u32(),
         _ => return Err(Error::InvalidOpCode),
     };
 
@@ -127,21 +159,16 @@ pub(crate) fn execute_load(
         Ok(())
     }
 
-    match instruction.id().as_u8() {
-        // LB
-        0b000 => exec(instruction, regs, memory, |n: i8| unsafe {
+    match instruction.id() {
+        LB => exec(instruction, regs, memory, |n: i8| unsafe {
             core::mem::transmute(n as i32)
         }),
-        // LBU
-        0b100 => exec(instruction, regs, memory, |n: u8| n as u32),
-        // LH
-        0b001 => exec(instruction, regs, memory, |n: I16| unsafe {
+        LBU => exec(instruction, regs, memory, |n: u8| n as u32),
+        LH => exec(instruction, regs, memory, |n: I16| unsafe {
             core::mem::transmute(n.as_i16() as i32)
         }),
-        // LHU
-        0b101 => exec(instruction, regs, memory, |n: U16| n.as_u16() as u32),
-        // LW
-        0b010 => exec(instruction, regs, memory, |n: U32| n.as_u32()),
+        LHU => exec(instruction, regs, memory, |n: U16| n.as_u16() as u32),
+        LW => exec(instruction, regs, memory, |n: U32| n.as_u32()),
         _ => Err(Error::InvalidOpCode),
     }
 }
@@ -205,14 +232,10 @@ pub(crate) fn execute_shifti(instruction: Shift, regs: &mut Registers<u32>) -> R
         Ok(())
     }
 
-    #[allow(clippy::unusual_byte_groupings)]
-    let f: fn(u32, u32) -> u32 = match instruction.id().as_u16() {
-        // SLLI
-        0b0000000_001 => |a, b| a.wrapping_shl(b),
-        // SRLI
-        0b0000000_101 => |a, b| a.wrapping_shr(b),
-        // SRAI
-        0b0100000_101 => |a, b| unsafe {
+    let f: fn(u32, u32) -> u32 = match instruction.id() {
+        SLLI => |a, b| a.wrapping_shl(b),
+        SRLI => |a, b| a.wrapping_shr(b),
+        SRAI => |a, b| unsafe {
             core::mem::transmute(core::mem::transmute::<_, i32>(a).wrapping_shr(b))
         },
         _ => return Err(Error::InvalidOpCode),
@@ -246,13 +269,10 @@ pub(crate) fn execute_store(
         mem::write(&f(src2), memory, offset)
     }
 
-    match instruction.id().as_u8() {
-        // SB
-        0b000 => exec(instruction, regs, memory, |n| n as u8),
-        // SH
-        0b001 => exec(instruction, regs, memory, |n| U16::new(n as u16)),
-        // SW
-        0b010 => exec(instruction, regs, memory, U32::new),
+    match instruction.id() {
+        SB => exec(instruction, regs, memory, |n| n as u8),
+        SH => exec(instruction, regs, memory, |n| U16::new(n as u16)),
+        SW => exec(instruction, regs, memory, U32::new),
         _ => Err(Error::InvalidOpCode),
     }
 }
@@ -278,19 +298,13 @@ pub(crate) fn execute_branch(
         Ok(())
     }
 
-    let f: fn(u32, u32) -> bool = match instruction.id().as_u8() {
-        // BEQ
-        0b000 => |a, b| a == b,
-        // BNE
-        0b001 => |a, b| a != b,
-        // BLT
-        0b100 => |a, b| unsafe { core::mem::transmute::<_, i32>(a) < core::mem::transmute(b) },
-        // BGE
-        0b101 => |a, b| unsafe { core::mem::transmute::<_, i32>(a) >= core::mem::transmute(b) },
-        // BLTU
-        0b110 => |a, b| a < b,
-        // BGEU
-        0b111 => |a, b| a >= b,
+    let f: fn(u32, u32) -> bool = match instruction.id() {
+        BEQ => |a, b| a == b,
+        BNE => |a, b| a != b,
+        BLT => |a, b| unsafe { core::mem::transmute::<_, i32>(a) < core::mem::transmute(b) },
+        BGE => |a, b| unsafe { core::mem::transmute::<_, i32>(a) >= core::mem::transmute(b) },
+        BLTU => |a, b| a < b,
+        BGEU => |a, b| a >= b,
         _ => return Err(Error::InvalidOpCode),
     };
 


### PR DESCRIPTION
This PR mainly fixes this two lines

https://github.com/DontPanicO/risky/blob/569025fd0a17be0eb523bd184d5ddf97d73a6d1e/src/decode.rs#L95
https://github.com/DontPanicO/risky/blob/569025fd0a17be0eb523bd184d5ddf97d73a6d1e/src/decode.rs#L177

For example:

`0b0000001 + 0b001 = 0b0000010`

but also

`0b0000000 + 0b010 = 0b0000010`

We need to concatenate funct7 and funct3 bits, so we'd better write

`(0b0000001 << 3) | 0b001 = 0b0000001001`

and

`(0b0000000 << 3) | 0b010 = 0b0000000010`.
